### PR TITLE
Email Encoding

### DIFF
--- a/404.html
+++ b/404.html
@@ -400,10 +400,10 @@
 	<div class="buttons-container">
 		<a class="border-button" href="https://libretexts.org" target="_blank"><span class="fa fa-home"></span> Home
 		                                                                                                        Page</a>
-		<a class="border-button" id="report" href="mailto:info@libretexts.org" target="_blank"><span
+		<a class="border-button" id="report" href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;" target="_blank"><span
 				class="fa fa-warning"></span> Report Problem</a>
 		<script>
-			document.getElementById("report").href = "mailto:info@libretexts.org?subject=Broken Page: " + window.location.href + "&body=" + window.location.href+" is not accessible";
+			document.getElementById("report").href = "mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;?subject=Broken Page: " + window.location.href + "&body=" + window.location.href+" is not accessible";
 		</script>
 	</div>
 </div>

--- a/about.html
+++ b/about.html
@@ -148,7 +148,7 @@
 									</div>
 								</li>
 								
-								<li><a href="mailto:info@libretexts.org">Contact</a></li>
+								<li><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;">Contact</a></li>
 								<li><a href="https://donorbox.org/libretexts">Donate</a></li>
 							
 							
@@ -244,7 +244,7 @@
 											<div class="col-12">
 												<div class="cta-content d-flex align-items-center justify-content-between flex-wrap">
 													<h3>Do you want have LibreTexts on your campus?</h3>
-													<a href="mailto:info@libretexts.org?Subject=Institution%20Adoption" class="btn academy-btn">Get in touch!</a>
+													<a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;?Subject=Institution%20Adoption" class="btn academy-btn">Get in touch!</a>
 												</div>
 											</div>
 										</div>
@@ -268,7 +268,7 @@
 											<div class="col-12">
 												<div class="cta-content d-flex align-items-center justify-content-between flex-wrap">
 													<h3>Want to help us make LibreTexts even better?</h3>
-													<a href="mailto:info@libretexts.org?Subject=Volunteer" class="btn academy-btn">Get in touch!</a>
+													<a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;?Subject=Volunteer" class="btn academy-btn">Get in touch!</a>
 												</div>
 											</div>
 										</div>
@@ -294,7 +294,7 @@
 			<!--[503(c)(3) pending]-->
 			<p>LibreTexts is a non-profit organization committed to freeing the
 			   textbook from the limitations and costs of traditional textbooks. Our freely accessible LibreTexts provide a more engaging learning experience for students without the financial burden.
-				<span> Do you want to have LibreTexts on your campus? <a href="mailto:info@libretexts.org"
+				<span> Do you want to have LibreTexts on your campus? <a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;"
 				                                                         class="normalLink">Contact Us</a></span>
 				<a href="https://www.facebook.com/LibreTexts/" class="normalLink"><i class="fa fa-facebook"></i></a>
 				<a href="https://twitter.com/libretexts?lang=en" class="normalLink"><i class="fa fa-twitter"></i></a>
@@ -369,7 +369,7 @@
 										</div>&ndash;&gt;
 				<div class="single-contact d-flex">
 					<i class="icon-mail"></i>
-					<p><a href="mailto:info@libretexts.org" class="normalLink">info@libretexts.org</a></p>
+					<p><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;" class="normalLink">info@libretexts.org</a></p>
 				</div>
 			</div>
 		</div>-->

--- a/advanced.html
+++ b/advanced.html
@@ -148,7 +148,7 @@
 									</div>
 								</li>
 								
-								<li><a href="mailto:info@libretexts.org">Contact</a></li>
+								<li><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;">Contact</a></li>
 								<li><a href="https://donorbox.org/libretexts">Donate</a></li>
 							
 							
@@ -207,7 +207,7 @@
 				   expand the capabilities of LibreTexts and to integrate with existing technologies at
 				   institutions such as their Learning Management Systems. Wishing for a feature that we haven't thought
 				   of yet? Don't be afraid to <a class="normalLink"
-				                                 href="mailto:info@libretexts.org?Subject=New%20Feature">suggest a
+				                                 href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;?Subject=New%20Feature">suggest a
 				                                                                                         feature!</a>
 				</p>
 			</div>
@@ -516,7 +516,7 @@ VBox([HBox([play_button, year_slider]), fig])
 		<div class="row">
 			<div class="col-12">
 				<div class="view-all text-center">
-					<a href="mailto:info@libretexts.org?Subject=New%20Feature" class="btn academy-btn">Suggest a
+					<a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;?Subject=New%20Feature" class="btn academy-btn">Suggest a
 					                                                                                   feature</a>
 				</div>
 			</div>
@@ -532,7 +532,7 @@ VBox([HBox([play_button, year_slider]), fig])
 			<div class="col-12">
 				<div class="cta-content d-flex align-items-center justify-content-between flex-wrap">
 					<h3>Do you want have LibreTexts on your campus? Get in touch!</h3>
-					<a href="mailto:info@libretexts.org" class="btn academy-btn">Contact Us</a>
+					<a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;" class="btn academy-btn">Contact Us</a>
 				</div>
 			</div>
 		</div>
@@ -604,7 +604,7 @@ VBox([HBox([play_button, year_slider]), fig])
 			<p>LibreTexts is a non-profit organization committed to freeing the
 			   textbook from the limitations and costs of traditional textbooks. Our open and freely accessible
 			   LibreTexts provide a more engaging learning experience for students without the financial burden.
-				<span> Do you want to have LibreTexts on your campus? <a href="mailto:info@libretexts.org"
+				<span> Do you want to have LibreTexts on your campus? <a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;"
 				                                                         class="normalLink">Contact Us</a></span>
 				<a href="https://www.facebook.com/LibreTexts/" class="normalLink"><i class="fa fa-facebook"></i></a>
 				<a href="https://twitter.com/libretexts?lang=en" class="normalLink"><i class="fa fa-twitter"></i></a>
@@ -679,7 +679,7 @@ VBox([HBox([play_button, year_slider]), fig])
 										</div>&ndash;&gt;
 				<div class="single-contact d-flex">
 					<i class="icon-mail"></i>
-					<p><a href="mailto:info@libretexts.org" class="normalLink">info@libretexts.org</a></p>
+					<p><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;" class="normalLink">info@libretexts.org</a></p>
 				</div>
 			</div>
 		</div>-->

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
 									</div>
 								</li>
 								
-								<li><a href="mailto:info@libretexts.org">Contact</a></li>
+								<li><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;">Contact</a></li>
 								<li><a href="https://donorbox.org/libretexts">Donate</a></li>
 							
 							
@@ -657,7 +657,7 @@
 			<p>LibreTexts is a non-profit organization committed to freeing the
 			   textbook from the limitations and costs of traditional textbooks. Our open and freely accessible
 			   LibreTexts provide a more engaging learning experience for students without the financial burden.
-				<span> Do you want to have LibreTexts on your campus? <a href="mailto:info@libretexts.org"
+				<span> Do you want to have LibreTexts on your campus? <a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;"
 				                                                         class="normalLink">Contact Us</a></span>
 				<a href="https://www.facebook.com/LibreTexts/" class="normalLink"><i class="fa fa-facebook"></i></a>
 				<a href="https://twitter.com/libretexts?lang=en" class="normalLink"><i class="fa fa-twitter"></i></a>
@@ -732,7 +732,7 @@
 										</div>&ndash;&gt;
 				<div class="single-contact d-flex">
 					<i class="icon-mail"></i>
-					<p><a href="mailto:info@libretexts.org" class="normalLink">info@libretexts.org</a></p>
+					<p><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;" class="normalLink">&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;</a></p>
 				</div>
 			</div>
 		</div>-->

--- a/mission.html
+++ b/mission.html
@@ -148,7 +148,7 @@
 									</div>
 								</li>
 								
-								<li><a href="mailto:info@libretexts.org">Contact</a></li>
+								<li><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;">Contact</a></li>
 								<li><a href="https://donorbox.org/libretexts">Donate</a></li>
 							
 							
@@ -311,7 +311,7 @@
 			<!--[503(c)(3) pending]-->
 			<p>LibreTexts is a non-profit organization committed to freeing the
 			   textbook from the limitations and costs of traditional textbooks. Our open and freely accessible LibreTexts provide a more engaging learning experience for students without the financial burden.
-				<span> Do you want to have LibreTexts on your campus? <a href="mailto:info@libretexts.org"
+				<span> Do you want to have LibreTexts on your campus? <a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;"
 				                                                         class="normalLink">Contact Us</a></span>
 				<a href="https://www.facebook.com/LibreTexts/" class="normalLink"><i class="fa fa-facebook"></i></a>
 				<a href="https://twitter.com/libretexts?lang=en" class="normalLink"><i class="fa fa-twitter"></i></a>
@@ -386,7 +386,7 @@
 										</div>&ndash;&gt;
 				<div class="single-contact d-flex">
 					<i class="icon-mail"></i>
-					<p><a href="mailto:info@libretexts.org" class="normalLink">info@libretexts.org</a></p>
+					<p><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;" class="normalLink">info@libretexts.org</a></p>
 				</div>
 			</div>
 		</div>-->

--- a/pressRelease.html
+++ b/pressRelease.html
@@ -148,7 +148,7 @@
 									</div>
 								</li>
 								
-								<li><a href="mailto:info@libretexts.org">Contact</a></li>
+								<li><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;">Contact</a></li>
 								<li><a href="https://donorbox.org/libretexts">Donate</a></li>
 							
 							
@@ -271,7 +271,7 @@
 			<!--[503(c)(3) pending]-->
 			<p>LibreTexts is a non-profit organization committed to freeing the
 			   textbook from the limitations and costs of traditional textbooks. Our open and freely accessible LibreTexts provide a more engaging learning experience for students without the financial burden.
-				<span> Do you want to have LibreTexts on your campus? <a href="mailto:info@libretexts.org"
+				<span> Do you want to have LibreTexts on your campus? <a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;"
 				                                                         class="normalLink">Contact Us</a></span>
 				<a href="https://www.facebook.com/LibreTexts/" class="normalLink"><i class="fa fa-facebook"></i></a>
 				<a href="https://twitter.com/libretexts?lang=en" class="normalLink"><i class="fa fa-twitter"></i></a>
@@ -346,7 +346,7 @@
 										</div>&ndash;&gt;
 				<div class="single-contact d-flex">
 					<i class="icon-mail"></i>
-					<p><a href="mailto:info@libretexts.org" class="normalLink">info@libretexts.org</a></p>
+					<p><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;" class="normalLink">info@libretexts.org</a></p>
 				</div>
 			</div>
 		</div>-->

--- a/team.html
+++ b/team.html
@@ -148,7 +148,7 @@
 									</div>
 								</li>
 								
-								<li><a href="mailto:info@libretexts.org">Contact</a></li>
+								<li><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;">Contact</a></li>
 								<li><a href="https://donorbox.org/libretexts">Donate</a></li>
 							
 							
@@ -2481,7 +2481,7 @@
 			                       accessible
 			                       LibreTexts provide a more engaging learning experience for students without the
 			                       financial burden.
-				<span> Do you want to have LibreTexts on your campus? <a href="mailto:info@libretexts.org"
+				<span> Do you want to have LibreTexts on your campus? <a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;"
 				                                                         class="normalLink">Contact Us</a></span>
 				<a href="https://www.facebook.com/LibreTexts/" class="normalLink"><i class="fa fa-facebook"></i></a>
 				<a href="https://twitter.com/libretexts?lang=en" class="normalLink"><i class="fa fa-twitter"></i></a>
@@ -2557,7 +2557,7 @@
 										</div>&ndash;&gt;
 				<div class="single-contact d-flex">
 					<i class="icon-mail"></i>
-					<div class="teamTitle"><a href="mailto:info@libretexts.org" class="normalLink">info@libretexts.org</a></div>
+					<div class="teamTitle"><a href="mailto:&#105;&#110;&#102;&#111;&#064;&#108;&#105;&#098;&#114;&#101;&#116;&#101;&#120;&#116;&#115;&#046;&#111;&#114;&#103;" class="normalLink">info@libretexts.org</a></div>
 				</div>
 			</div>
 		</div>-->


### PR DESCRIPTION
My web design professor said if the actual email address is in the html file, it is at risk of being found and used by spambots. To avoid this, an email encoder like this one http://wbwip.com/wbw/emailencoder.html is used to encode the address to make it harder for spambots to read. I have copy pasted the code where I saw the address. It should display and link like a normal email address on the website, but not be as vulnerable.